### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   <a href="https://www.npmjs.org/package/create-node-sandbox"><img src="https://badgen.net/npm/dt/create-node-sandbox" alt="downloads"/></a>
   <a href="https://github.com/lirantal/create-node-sandbox/actions?workflow=CI"><img src="https://github.com/lirantal/create-node-sandbox/workflows/CI/badge.svg" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/create-node-sandbox"><img src="https://badgen.net/codecov/c/github/lirantal/create-node-sandbox" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/create-node-sandbox"><img src="https://snyk.io/test/github/lirantal/create-node-sandbox/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.